### PR TITLE
Add EntryValidator to allow automatic fallback to default value

### DIFF
--- a/modules/lime-api/pom.xml
+++ b/modules/lime-api/pom.xml
@@ -15,13 +15,6 @@
     <build>
         <finalName>${pluginName}-Standalone</finalName>
 
-        <!--        <resources>-->
-        <!--            <resource>-->
-        <!--                <directory>src/main/resources</directory>-->
-        <!--                <filtering>true</filtering>-->
-        <!--            </resource>-->
-        <!--        </resources>-->
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/LimeDevUtility.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/LimeDevUtility.java
@@ -1,4 +1,4 @@
-package de.sprax2013.lime.configuration;
+package de.sprax2013.lime;
 
 import java.util.logging.Logger;
 

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/LimeDevUtility.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/LimeDevUtility.java
@@ -4,4 +4,8 @@ import java.util.logging.Logger;
 
 public class LimeDevUtility {
     public static final Logger LOGGER = Logger.getLogger("LimeDevUtility");
+
+    private LimeDevUtility() {
+        throw new IllegalStateException("Utility class");
+    }
 }

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
@@ -209,7 +209,7 @@ public class Config {
                             EntryValidator validator = cfgEntry.getEntryValidator();
 
                             if (validator != null && !validator.isValid(value)) {
-                                LimeDevUtility.LOGGER.warning("Invalid value(=" + value +
+                                LimeDevUtility.LOGGER.warning(() -> "Invalid value(=" + value +
                                         ") inside " + this.file.getName() + " for '" + cfgEntry.getKey() +
                                         "' (default value: '" + cfgEntry.getDefaultValue() + "')");
                             }
@@ -404,6 +404,7 @@ public class Config {
         return yaml;
     }
 
+    @SuppressWarnings("SameParameterValue")
     private static String repeatString(String s, int count) {
         if (count < 0) throw new IllegalArgumentException();
         if (count == 0 || s.isEmpty()) return "";

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
@@ -1,5 +1,6 @@
 package de.sprax2013.lime.configuration;
 
+import de.sprax2013.lime.LimeDevUtility;
 import de.sprax2013.lime.configuration.validation.EntryValidator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class Config {
+    private static final String ERR_NO_FILE = "You have to set a file for the configuration";
+
     private static Yaml yaml;
 
     private final Map<@NotNull String, @NotNull ConfigEntry> entries = new LinkedHashMap<>(),
@@ -71,7 +73,7 @@ public class Config {
         String comment = this.commentProvider != null ? this.commentProvider.getComment() : null;
 
         if (comment != null && !comment.isEmpty()) {
-            return "# " + comment.replaceAll("\n", "\n# ") + "\n\n";
+            return "# " + comment.replace("\n", "\n# ") + "\n\n";
         }
 
         return null;
@@ -164,14 +166,14 @@ public class Config {
             loadWithException();
             return true;
         } catch (IOException ex) {
-            ex.printStackTrace();
+            LimeDevUtility.LOGGER.throwing(this.getClass().getName(), "load", ex);
         }
 
         return false;
     }
 
     public void loadWithException() throws IOException {
-        if (this.file == null) throw new FileNotFoundException("You have to set a file for the configuration");
+        if (this.file == null) throw new FileNotFoundException(ERR_NO_FILE);
 
         reset();
 
@@ -226,14 +228,14 @@ public class Config {
             saveWithException();
             return true;
         } catch (IOException ex) {
-            ex.printStackTrace();
+            LimeDevUtility.LOGGER.throwing(this.getClass().getName(), "save", ex);
         }
 
         return false;
     }
 
     public void saveWithException() throws IOException {
-        if (this.file == null) throw new FileNotFoundException("You have to set a file for the configuration");
+        if (this.file == null) throw new FileNotFoundException(ERR_NO_FILE);
 
         // In case #toString() throws an exception,
         // the file's content is not deleted
@@ -245,7 +247,7 @@ public class Config {
     }
 
     public void backupFile() throws IOException {
-        if (this.file == null) throw new FileNotFoundException("You have to set a file for the configuration");
+        if (this.file == null) throw new FileNotFoundException(ERR_NO_FILE);
         if (!this.file.exists()) throw new FileNotFoundException("File '" + this.file.getAbsolutePath() +
                 "' does not exist");
 

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/Config.java
@@ -1,5 +1,6 @@
 package de.sprax2013.lime.configuration;
 
+import de.sprax2013.lime.configuration.validation.EntryValidator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.DumperOptions;
@@ -202,6 +203,14 @@ public class Config {
                         Object value = ((Map<?, ?>) obj).get(nodeTree[nodeTree.length - 1]);
 
                         if (value != null) {
+                            EntryValidator validator = cfgEntry.getEntryValidator();
+
+                            if (validator != null && !validator.isValid(value)) {
+                                LimeDevUtility.LOGGER.warning("Invalid value(=" + value +
+                                        ") inside " + this.file.getName() + " for '" + cfgEntry.getKey() +
+                                        "' (default value: '" + cfgEntry.getDefaultValue() + "')");
+                            }
+
                             cfgEntry.setValue(value);
                         }
                     }

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/ConfigEntry.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/ConfigEntry.java
@@ -1,8 +1,10 @@
 package de.sprax2013.lime.configuration;
 
+import de.sprax2013.lime.configuration.validation.EntryValidator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -10,6 +12,8 @@ import java.util.Objects;
 public class ConfigEntry {
     private final @NotNull String key;
     private final @Nullable Object defaultValue;
+
+    private @Nullable EntryValidator entryValidator;
     private @Nullable ConfigCommentProvider commentProvider;
 
     private Object value;
@@ -34,14 +38,29 @@ public class ConfigEntry {
         return this.defaultValue;
     }
 
+    public @NotNull ConfigEntry setEntryValidator(@Nullable EntryValidator entryValidator) {
+        if (entryValidator != null && !entryValidator.isValid(this.defaultValue))
+            throw new IllegalArgumentException("The EntryValidator returns false for the Entry's default value");
+
+        this.entryValidator = entryValidator;
+
+        return this;
+    }
+
+    public @Nullable EntryValidator getEntryValidator() {
+        return this.entryValidator;
+    }
+
     /**
      * Be informed, that according to the YAML 1.1 spec,
      * comments may not associated with a particular node (witch is exactly what this method is for)
      *
      * @see <a href="https://yaml.org/spec/1.1/current.html#id864687">YAML 1.1 spec</a>
      */
-    public void setCommentProvider(@Nullable ConfigCommentProvider commentProvider) {
+    public @NotNull ConfigEntry setCommentProvider(@Nullable ConfigCommentProvider commentProvider) {
         this.commentProvider = commentProvider;
+
+        return this;
     }
 
     public @Nullable ConfigCommentProvider getCommentProvider() {
@@ -58,8 +77,8 @@ public class ConfigEntry {
         return null;
     }
 
-    public ConfigEntry setValue(@Nullable Object value) {
-        this.value = value;
+    public @NotNull ConfigEntry setValue(@Nullable Object value) {
+        this.value = value instanceof Object[] ? Arrays.asList((Object[]) value) : value;
 
         return this;
     }
@@ -78,59 +97,131 @@ public class ConfigEntry {
     }
 
     public boolean getValueAsBoolean() {
-        return this.value instanceof Boolean ?
-                (boolean) this.value :
-                Boolean.parseBoolean((String) this.value);
+        Object result;
+
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        return result instanceof Boolean ?
+                (boolean) result :
+                Boolean.parseBoolean((String) result);
     }
 
     public int getValueAsInt() {
-        if (this.value == null) return 0;
+        Object result;
 
-        return this.value instanceof Integer ?
-                (int) this.value :
-                Integer.parseInt((String) this.value);
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        if (result == null) return 0;
+
+        return result instanceof Integer ?
+                (int) result :
+                Integer.parseInt((String) result);
     }
 
     public long getValueAsLong() {
-        if (this.value == null) return 0;
+        Object result;
 
-        return this.value instanceof Long ?
-                (long) this.value :
-                Long.parseLong((String) this.value);
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        if (result == null) return 0;
+
+        return result instanceof Long ?
+                (long) result :
+                Long.parseLong((String) result);
     }
 
     public float getValueAsFloat() {
-        if (this.value == null) return 0;
+        Object result;
 
-        return this.value instanceof Float ?
-                (float) this.value :
-                Float.parseFloat((String) this.value);
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        if (result == null) return 0;
+
+        return result instanceof Float ?
+                (float) result :
+                Float.parseFloat((String) result);
     }
 
     public double getValueAsDouble() {
-        if (this.value == null) return 0;
+        Object result;
 
-        return this.value instanceof Double ?
-                (double) this.value :
-                Double.parseDouble((String) this.value);
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        if (result == null) return 0;
+
+        return result instanceof Double ?
+                (double) result :
+                Double.parseDouble((String) result);
     }
 
     public @Nullable String getValueAsString() {
-        return (String) this.value;
+        Object result;
+
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        return result == null ? null : result.toString();
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable List<Object> getValueAsList() {
-        return (List<Object>) this.value;
+        Object result;
+
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        return (List<Object>) result;
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable List<Integer> getValueAsIntList() {
-        return (List<Integer>) this.value;
+        Object result;
+
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        return (List<Integer>) result;
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable List<String> getValueAsStringList() {
-        return (List<String>) this.value;
+        Object result;
+
+        if (entryValidator == null || entryValidator.isValid(this.value)) {
+            result = this.value;
+        } else {
+            result = this.defaultValue;
+        }
+
+        return (List<String>) result;
     }
 }

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/EntryValidator.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/EntryValidator.java
@@ -1,0 +1,5 @@
+package de.sprax2013.lime.configuration.validation;
+
+public interface EntryValidator {
+    boolean isValid(Object value);
+}

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/IntEntryValidator.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/IntEntryValidator.java
@@ -1,0 +1,26 @@
+package de.sprax2013.lime.configuration.validation;
+
+public class IntEntryValidator implements EntryValidator {
+    private static final IntEntryValidator instance = new IntEntryValidator();
+
+    private IntEntryValidator() {
+    }
+
+    @Override
+    public boolean isValid(Object value) {
+        if (value == null) return false;
+        if (value instanceof Integer) return true;
+
+        try {
+            Integer.parseInt(value.toString());
+
+            return true;
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+
+    public static IntEntryValidator get() {
+        return instance;
+    }
+}

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/IntEntryValidator.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/IntEntryValidator.java
@@ -4,6 +4,7 @@ public class IntEntryValidator implements EntryValidator {
     private static final IntEntryValidator instance = new IntEntryValidator();
 
     private IntEntryValidator() {
+        throw new IllegalStateException("Utility class");
     }
 
     @Override

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/StringEntryValidator.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/StringEntryValidator.java
@@ -1,0 +1,17 @@
+package de.sprax2013.lime.configuration.validation;
+
+public class StringEntryValidator implements EntryValidator {
+    private static final StringEntryValidator instance = new StringEntryValidator();
+
+    private StringEntryValidator() {
+    }
+
+    @Override
+    public boolean isValid(Object value) {
+        return value != null;
+    }
+
+    public static StringEntryValidator get() {
+        return instance;
+    }
+}

--- a/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/StringEntryValidator.java
+++ b/modules/lime-api/src/main/java/de/sprax2013/lime/configuration/validation/StringEntryValidator.java
@@ -4,6 +4,7 @@ public class StringEntryValidator implements EntryValidator {
     private static final StringEntryValidator instance = new StringEntryValidator();
 
     private StringEntryValidator() {
+        throw new IllegalStateException("Utility class");
     }
 
     @Override

--- a/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/LimeDevUtilitySpigot.java
+++ b/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/LimeDevUtilitySpigot.java
@@ -13,6 +13,8 @@ public class LimeDevUtilitySpigot {
 
         initialized = true;
 
+        LimeDevUtility.LOGGER.setParent(plugin.getLogger());
+
         try {
             // TODO: Add Custom ServerVersion-Pie that shows NMS-Versions when clicked
             new MetricsLite(plugin);

--- a/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/LimeDevUtilitySpigot.java
+++ b/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/LimeDevUtilitySpigot.java
@@ -1,6 +1,6 @@
 package de.sprax2013.lime.spigot;
 
-import de.sprax2013.lime.configuration.LimeDevUtility;
+import de.sprax2013.lime.LimeDevUtility;
 import de.sprax2013.lime.spigot.bstats.MetricsLite;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/LimeDevUtilitySpigot.java
+++ b/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/LimeDevUtilitySpigot.java
@@ -8,6 +8,10 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class LimeDevUtilitySpigot {
     private static boolean initialized = false;
 
+    private LimeDevUtilitySpigot() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static void init(JavaPlugin plugin) {
         if (initialized) return;
 

--- a/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/bstats/MetricsLite.java
+++ b/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/bstats/MetricsLite.java
@@ -3,6 +3,7 @@ package de.sprax2013.lime.spigot.bstats;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import de.sprax2013.lime.configuration.LimeDevUtility;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -61,7 +62,7 @@ public class MetricsLite {
             version = props.getProperty("version");
             bStatsID = props.getProperty("bStatsID", "");
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LimeDevUtility.LOGGER.throwing(MetricsLite.class.getName(), "static-block", ex);
         }
 
         pluginName = name;

--- a/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/bstats/MetricsLite.java
+++ b/modules/spigot/lime-spigot-api/src/main/java/de/sprax2013/lime/spigot/bstats/MetricsLite.java
@@ -3,7 +3,7 @@ package de.sprax2013.lime.spigot.bstats;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import de.sprax2013.lime.configuration.LimeDevUtility;
+import de.sprax2013.lime.LimeDevUtility;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Used for static code analysis on https://sonarcloud.io/dashboard?id=SpraxDev_BetterChairs -->
+        <!-- Used for static code analysis on https://sonarcloud.io/dashboard?id=SpraxDev_LimeDevUtility -->
         <sonar.projectKey>SpraxDev_LimeDevUtility</sonar.projectKey>
         <sonar.organization>sprax2013</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,14 @@
 
     <distributionManagement>
         <repository>
-            <id>GitHub-SpraxDev</id>
-            <url>https://maven.pkg.github.com/SpraxDev/LimeDevUtility</url>
+            <id>sprax-repo</id>
+            <url>https://repo.sprax2013.de/repository/maven-releases/</url>
         </repository>
+
+        <snapshotRepository>
+            <id>sprax-repo</id>
+            <url>https://repo.sprax2013.de/repository/maven-snapshots/</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <repositories>


### PR DESCRIPTION
If you provide an EntryValidator for an ConfigEntry and it returns `false` in on of the `#getAs...()` methods, it will automatically use the default value but without changing the current/normal/user value. This ensurs, that the file is not modified.

Additionally, the user is informed about a value being invalid and the default value as an example.